### PR TITLE
Add stack frame and stack trace parquet output

### DIFF
--- a/src/commands/dump_to_parquet.rs
+++ b/src/commands/dump_to_parquet.rs
@@ -801,6 +801,94 @@ fn write_class_hierarchy(index: &HprofIndex) {
     writer.close().unwrap();
 }
 
+/// Build `_stack_frames` WritableBatch: frame_id, class_name, method_name, method_signature, source_file, line_num.
+fn build_stack_frames_batch(index: &HprofIndex) -> Option<WritableBatch> {
+    if index.stack_frames.is_empty() {
+        return None;
+    }
+
+    let len = index.stack_frames.len();
+    let mut frame_ids: Vec<u64> = Vec::with_capacity(len);
+    let mut class_names: Vec<&str> = Vec::with_capacity(len);
+    let mut method_names: Vec<&str> = Vec::with_capacity(len);
+    let mut method_sigs: Vec<&str> = Vec::with_capacity(len);
+    let mut source_files: Vec<&str> = Vec::with_capacity(len);
+    let mut line_nums: Vec<i32> = Vec::with_capacity(len);
+
+    for sf in &index.stack_frames {
+        frame_ids.push(sf.frame_id);
+        class_names.push(&sf.class_name);
+        method_names.push(&sf.method_name);
+        method_sigs.push(&sf.method_signature);
+        source_files.push(&sf.source_file);
+        line_nums.push(sf.line_num);
+    }
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("frame_id", DataType::UInt64, false),
+        Field::new("class_name", DataType::Utf8, false),
+        Field::new("method_name", DataType::Utf8, false),
+        Field::new("method_signature", DataType::Utf8, false),
+        Field::new("source_file", DataType::Utf8, false),
+        Field::new("line_num", DataType::Int32, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt64Array::from(frame_ids)) as Arc<dyn Array>,
+            Arc::new(StringArray::from(class_names)) as Arc<dyn Array>,
+            Arc::new(StringArray::from(method_names)) as Arc<dyn Array>,
+            Arc::new(StringArray::from(method_sigs)) as Arc<dyn Array>,
+            Arc::new(StringArray::from(source_files)) as Arc<dyn Array>,
+            Arc::new(Int32Array::from(line_nums)) as Arc<dyn Array>,
+        ],
+    ).unwrap();
+
+    println!("  Built {} stack frames for _stack_frames.parquet", len);
+    Some(WritableBatch { file_key: "_stack_frames".into(), schema, batch })
+}
+
+/// Build `_stack_traces` WritableBatch: stack_trace_serial, thread_serial, frame_ids (list of u64).
+fn build_stack_traces_batch(index: &HprofIndex) -> Option<WritableBatch> {
+    if index.stack_traces.is_empty() {
+        return None;
+    }
+
+    let len = index.stack_traces.len();
+    let mut trace_serials: Vec<u32> = Vec::with_capacity(len);
+    let mut thread_serials: Vec<u32> = Vec::with_capacity(len);
+    let mut frame_id_lists = ListBuilder::new(UInt64Builder::new());
+
+    for st in &index.stack_traces {
+        trace_serials.push(st.stack_trace_serial);
+        thread_serials.push(st.thread_serial);
+        let values = frame_id_lists.values();
+        for &fid in &st.frame_ids {
+            values.append_value(fid);
+        }
+        frame_id_lists.append(true);
+    }
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("stack_trace_serial", DataType::UInt32, false),
+        Field::new("thread_serial", DataType::UInt32, false),
+        Field::new("frame_ids", DataType::List(Arc::new(Field::new("item", DataType::UInt64, true))), false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(UInt32Array::from(trace_serials)) as Arc<dyn Array>,
+            Arc::new(UInt32Array::from(thread_serials)) as Arc<dyn Array>,
+            Arc::new(frame_id_lists.finish()) as Arc<dyn Array>,
+        ],
+    ).unwrap();
+
+    println!("  Built {} stack traces for _stack_traces.parquet", len);
+    Some(WritableBatch { file_key: "_stack_traces".into(), schema, batch })
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
@@ -862,9 +950,15 @@ pub fn dump_objects_to_parquet(hprof: &Hprof, _flush_row_threshold: usize, robo_
         });
     });
 
-    // Write static fields
+    // Write static fields, stack frames, and stack traces through the pool
     if let Some(sb) = build_static_fields_batch(&index, robo_mode) {
         pool.write_batch(sb);
+    }
+    if let Some(sf) = build_stack_frames_batch(&index) {
+        pool.write_batch(sf);
+    }
+    if let Some(st) = build_stack_traces_batch(&index) {
+        pool.write_batch(st);
     }
 
     let pass2_dur = t1.elapsed();
@@ -874,4 +968,313 @@ pub fn dump_objects_to_parquet(hprof: &Hprof, _flush_row_threshold: usize, robo_
     let t2 = Instant::now();
     pool.close_all();
     println!("Writers closed in {:.1}s", t2.elapsed().as_secs_f64());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hprof_index::{HprofIndex, ResolvedStackFrame, ResolvedStackTrace};
+    use arrow_array::{cast::AsArray, types::UInt64Type};
+
+    /// Create a minimal HprofIndex with only stack_frames and stack_traces populated.
+    fn make_test_index<'a>(
+        frames: Vec<ResolvedStackFrame>,
+        traces: Vec<ResolvedStackTrace>,
+    ) -> HprofIndex<'a> {
+        HprofIndex {
+            utf8: HashMap::new(),
+            load_classes: HashMap::new(),
+            classes: HashMap::new(),
+            obj_id_to_class_obj_id: DashMap::new(),
+            prim_array_obj_id_to_type: DashMap::new(),
+            class_instance_field_descriptors: HashMap::new(),
+            class_field_declaring_classes: HashMap::new(),
+            stack_frames: frames,
+            stack_traces: traces,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // build_stack_frames_batch tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_stack_frames_batch_empty_returns_none() {
+        let index = make_test_index(vec![], vec![]);
+        assert!(build_stack_frames_batch(&index).is_none());
+    }
+
+    #[test]
+    fn test_build_stack_frames_batch_single_frame() {
+        let frames = vec![ResolvedStackFrame {
+            frame_id: 42,
+            method_name: "run".to_string(),
+            method_signature: "()V".to_string(),
+            source_file: "Main.java".to_string(),
+            class_name: "com.example.Main".to_string(),
+            line_num: 100,
+        }];
+        let index = make_test_index(frames, vec![]);
+        let wb = build_stack_frames_batch(&index).expect("should produce a batch");
+
+        assert_eq!(wb.file_key, "_stack_frames");
+        assert_eq!(wb.batch.num_rows(), 1);
+        assert_eq!(wb.batch.num_columns(), 6);
+
+        // Verify column values
+        let frame_ids = wb.batch.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
+        assert_eq!(frame_ids.value(0), 42);
+
+        let class_names = wb.batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(class_names.value(0), "com.example.Main");
+
+        let method_names = wb.batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(method_names.value(0), "run");
+
+        let method_sigs = wb.batch.column(3).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(method_sigs.value(0), "()V");
+
+        let source_files = wb.batch.column(4).as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(source_files.value(0), "Main.java");
+
+        let line_nums = wb.batch.column(5).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(line_nums.value(0), 100);
+    }
+
+    #[test]
+    fn test_build_stack_frames_batch_multiple_frames() {
+        let frames = vec![
+            ResolvedStackFrame {
+                frame_id: 1,
+                method_name: "methodA".to_string(),
+                method_signature: "(I)V".to_string(),
+                source_file: "A.java".to_string(),
+                class_name: "com.example.A".to_string(),
+                line_num: 10,
+            },
+            ResolvedStackFrame {
+                frame_id: 2,
+                method_name: "methodB".to_string(),
+                method_signature: "(Ljava/lang/String;)I".to_string(),
+                source_file: "B.java".to_string(),
+                class_name: "com.example.B".to_string(),
+                line_num: -1, // unknown
+            },
+            ResolvedStackFrame {
+                frame_id: 3,
+                method_name: "nativeCall".to_string(),
+                method_signature: "()J".to_string(),
+                source_file: "(unknown)".to_string(),
+                class_name: "sun.misc.Unsafe".to_string(),
+                line_num: -3, // native method
+            },
+        ];
+        let index = make_test_index(frames, vec![]);
+        let wb = build_stack_frames_batch(&index).unwrap();
+
+        assert_eq!(wb.batch.num_rows(), 3);
+
+        let frame_ids = wb.batch.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
+        assert_eq!(frame_ids.value(0), 1);
+        assert_eq!(frame_ids.value(1), 2);
+        assert_eq!(frame_ids.value(2), 3);
+
+        let line_nums = wb.batch.column(5).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(line_nums.value(0), 10);
+        assert_eq!(line_nums.value(1), -1); // unknown
+        assert_eq!(line_nums.value(2), -3); // native
+    }
+
+    #[test]
+    fn test_build_stack_frames_batch_all_line_num_variants() {
+        let frames = vec![
+            ResolvedStackFrame {
+                frame_id: 1, method_name: "a".into(), method_signature: "".into(),
+                source_file: "".into(), class_name: "".into(), line_num: 42, // Normal
+            },
+            ResolvedStackFrame {
+                frame_id: 2, method_name: "b".into(), method_signature: "".into(),
+                source_file: "".into(), class_name: "".into(), line_num: -1, // Unknown
+            },
+            ResolvedStackFrame {
+                frame_id: 3, method_name: "c".into(), method_signature: "".into(),
+                source_file: "".into(), class_name: "".into(), line_num: -2, // Compiled
+            },
+            ResolvedStackFrame {
+                frame_id: 4, method_name: "d".into(), method_signature: "".into(),
+                source_file: "".into(), class_name: "".into(), line_num: -3, // Native
+            },
+        ];
+        let index = make_test_index(frames, vec![]);
+        let wb = build_stack_frames_batch(&index).unwrap();
+
+        let line_nums = wb.batch.column(5).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(line_nums.value(0), 42);
+        assert_eq!(line_nums.value(1), -1);
+        assert_eq!(line_nums.value(2), -2);
+        assert_eq!(line_nums.value(3), -3);
+    }
+
+    #[test]
+    fn test_build_stack_frames_batch_schema() {
+        let frames = vec![ResolvedStackFrame {
+            frame_id: 1, method_name: "m".into(), method_signature: "()V".into(),
+            source_file: "X.java".into(), class_name: "X".into(), line_num: 1,
+        }];
+        let index = make_test_index(frames, vec![]);
+        let wb = build_stack_frames_batch(&index).unwrap();
+
+        let fields: Vec<(&str, &DataType)> = wb.schema.fields().iter()
+            .map(|f| (f.name().as_str(), f.data_type()))
+            .collect();
+        assert_eq!(fields, vec![
+            ("frame_id", &DataType::UInt64),
+            ("class_name", &DataType::Utf8),
+            ("method_name", &DataType::Utf8),
+            ("method_signature", &DataType::Utf8),
+            ("source_file", &DataType::Utf8),
+            ("line_num", &DataType::Int32),
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_stack_traces_batch tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_stack_traces_batch_empty_returns_none() {
+        let index = make_test_index(vec![], vec![]);
+        assert!(build_stack_traces_batch(&index).is_none());
+    }
+
+    #[test]
+    fn test_build_stack_traces_batch_single_trace() {
+        let traces = vec![ResolvedStackTrace {
+            stack_trace_serial: 1,
+            thread_serial: 10,
+            frame_ids: vec![100, 200, 300],
+        }];
+        let index = make_test_index(vec![], traces);
+        let wb = build_stack_traces_batch(&index).expect("should produce a batch");
+
+        assert_eq!(wb.file_key, "_stack_traces");
+        assert_eq!(wb.batch.num_rows(), 1);
+        assert_eq!(wb.batch.num_columns(), 3);
+
+        let trace_serials = wb.batch.column(0).as_any().downcast_ref::<UInt32Array>().unwrap();
+        assert_eq!(trace_serials.value(0), 1);
+
+        let thread_serials = wb.batch.column(1).as_any().downcast_ref::<UInt32Array>().unwrap();
+        assert_eq!(thread_serials.value(0), 10);
+
+        // Verify list column
+        let frame_ids_col = wb.batch.column(2).as_list::<i32>();
+        let row0 = frame_ids_col.value(0);
+        let values = row0.as_primitive::<UInt64Type>();
+        assert_eq!(values.values(), &[100, 200, 300]);
+    }
+
+    #[test]
+    fn test_build_stack_traces_batch_multiple_traces_varying_depth() {
+        let traces = vec![
+            ResolvedStackTrace {
+                stack_trace_serial: 1,
+                thread_serial: 10,
+                frame_ids: vec![100],
+            },
+            ResolvedStackTrace {
+                stack_trace_serial: 2,
+                thread_serial: 20,
+                frame_ids: vec![200, 300, 400, 500],
+            },
+            ResolvedStackTrace {
+                stack_trace_serial: 3,
+                thread_serial: 30,
+                frame_ids: vec![], // empty stack trace (e.g., system thread)
+            },
+        ];
+        let index = make_test_index(vec![], traces);
+        let wb = build_stack_traces_batch(&index).unwrap();
+
+        assert_eq!(wb.batch.num_rows(), 3);
+
+        let trace_serials = wb.batch.column(0).as_any().downcast_ref::<UInt32Array>().unwrap();
+        assert_eq!(trace_serials.value(0), 1);
+        assert_eq!(trace_serials.value(1), 2);
+        assert_eq!(trace_serials.value(2), 3);
+
+        let frame_ids_col = wb.batch.column(2).as_list::<i32>();
+
+        // Trace 1: single frame
+        let row0 = frame_ids_col.value(0);
+        assert_eq!(row0.as_primitive::<UInt64Type>().values(), &[100]);
+
+        // Trace 2: four frames
+        let row1 = frame_ids_col.value(1);
+        assert_eq!(row1.as_primitive::<UInt64Type>().values(), &[200, 300, 400, 500]);
+
+        // Trace 3: empty
+        let row2 = frame_ids_col.value(2);
+        assert_eq!(row2.as_primitive::<UInt64Type>().len(), 0);
+    }
+
+    #[test]
+    fn test_build_stack_traces_batch_schema() {
+        let traces = vec![ResolvedStackTrace {
+            stack_trace_serial: 1, thread_serial: 1, frame_ids: vec![1],
+        }];
+        let index = make_test_index(vec![], traces);
+        let wb = build_stack_traces_batch(&index).unwrap();
+
+        let fields: Vec<(&str, &DataType)> = wb.schema.fields().iter()
+            .map(|f| (f.name().as_str(), f.data_type()))
+            .collect();
+        assert_eq!(fields[0], ("stack_trace_serial", &DataType::UInt32));
+        assert_eq!(fields[1], ("thread_serial", &DataType::UInt32));
+        assert_eq!(fields[2].0, "frame_ids");
+        match fields[2].1 {
+            DataType::List(_) => {} // expected
+            other => panic!("Expected List type for frame_ids, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration: both batches built from same index
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_both_batches_from_populated_index() {
+        let frames = vec![
+            ResolvedStackFrame {
+                frame_id: 100, method_name: "run".into(), method_signature: "()V".into(),
+                source_file: "Thread.java".into(), class_name: "java.lang.Thread".into(), line_num: 748,
+            },
+            ResolvedStackFrame {
+                frame_id: 200, method_name: "main".into(), method_signature: "([Ljava/lang/String;)V".into(),
+                source_file: "App.java".into(), class_name: "com.example.App".into(), line_num: 15,
+            },
+        ];
+        let traces = vec![ResolvedStackTrace {
+            stack_trace_serial: 1,
+            thread_serial: 5,
+            frame_ids: vec![100, 200],
+        }];
+        let index = make_test_index(frames, traces);
+
+        let sf_batch = build_stack_frames_batch(&index).unwrap();
+        let st_batch = build_stack_traces_batch(&index).unwrap();
+
+        assert_eq!(sf_batch.batch.num_rows(), 2);
+        assert_eq!(st_batch.batch.num_rows(), 1);
+
+        // Verify frame_ids in the trace reference valid frame_id values from frames
+        let trace_frame_ids = st_batch.batch.column(2).as_list::<i32>().value(0);
+        let trace_fids = trace_frame_ids.as_primitive::<UInt64Type>();
+        let frame_id_col = sf_batch.batch.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
+        for i in 0..trace_fids.len() {
+            let fid = trace_fids.value(i);
+            let found = (0..frame_id_col.len()).any(|j| frame_id_col.value(j) == fid);
+            assert!(found, "frame_id {} from trace not found in stack_frames", fid);
+        }
+    }
 }

--- a/src/commands/dump_to_parquet.rs
+++ b/src/commands/dump_to_parquet.rs
@@ -858,7 +858,8 @@ fn build_stack_traces_batch(index: &HprofIndex) -> Option<WritableBatch> {
     let len = index.stack_traces.len();
     let mut trace_serials: Vec<u32> = Vec::with_capacity(len);
     let mut thread_serials: Vec<u32> = Vec::with_capacity(len);
-    let mut frame_id_lists = ListBuilder::new(UInt64Builder::new());
+    let total_frame_refs: usize = index.stack_traces.iter().map(|st| st.frame_ids.len()).sum();
+    let mut frame_id_lists = ListBuilder::new(UInt64Builder::with_capacity(total_frame_refs));
 
     for st in &index.stack_traces {
         trace_serials.push(st.stack_trace_serial);
@@ -978,7 +979,7 @@ mod tests {
 
     /// Create a minimal HprofIndex with only stack_frames and stack_traces populated.
     fn make_test_index<'a>(
-        frames: Vec<ResolvedStackFrame>,
+        frames: Vec<ResolvedStackFrame<'a>>,
         traces: Vec<ResolvedStackTrace>,
     ) -> HprofIndex<'a> {
         HprofIndex {
@@ -1008,10 +1009,10 @@ mod tests {
     fn test_build_stack_frames_batch_single_frame() {
         let frames = vec![ResolvedStackFrame {
             frame_id: 42,
-            method_name: "run".to_string(),
-            method_signature: "()V".to_string(),
-            source_file: "Main.java".to_string(),
-            class_name: "com.example.Main".to_string(),
+            method_name: "run",
+            method_signature: "()V",
+            source_file: "Main.java",
+            class_name: "com.example.Main",
             line_num: 100,
         }];
         let index = make_test_index(frames, vec![]);
@@ -1046,26 +1047,26 @@ mod tests {
         let frames = vec![
             ResolvedStackFrame {
                 frame_id: 1,
-                method_name: "methodA".to_string(),
-                method_signature: "(I)V".to_string(),
-                source_file: "A.java".to_string(),
-                class_name: "com.example.A".to_string(),
+                method_name: "methodA",
+                method_signature: "(I)V",
+                source_file: "A.java",
+                class_name: "com.example.A",
                 line_num: 10,
             },
             ResolvedStackFrame {
                 frame_id: 2,
-                method_name: "methodB".to_string(),
-                method_signature: "(Ljava/lang/String;)I".to_string(),
-                source_file: "B.java".to_string(),
-                class_name: "com.example.B".to_string(),
+                method_name: "methodB",
+                method_signature: "(Ljava/lang/String;)I",
+                source_file: "B.java",
+                class_name: "com.example.B",
                 line_num: -1, // unknown
             },
             ResolvedStackFrame {
                 frame_id: 3,
-                method_name: "nativeCall".to_string(),
-                method_signature: "()J".to_string(),
-                source_file: "(unknown)".to_string(),
-                class_name: "sun.misc.Unsafe".to_string(),
+                method_name: "nativeCall",
+                method_signature: "()J",
+                source_file: "(unknown)",
+                class_name: "sun.misc.Unsafe",
                 line_num: -3, // native method
             },
         ];
@@ -1089,20 +1090,20 @@ mod tests {
     fn test_build_stack_frames_batch_all_line_num_variants() {
         let frames = vec![
             ResolvedStackFrame {
-                frame_id: 1, method_name: "a".into(), method_signature: "".into(),
-                source_file: "".into(), class_name: "".into(), line_num: 42, // Normal
+                frame_id: 1, method_name: "a", method_signature: "",
+                source_file: "", class_name: "", line_num: 42, // Normal
             },
             ResolvedStackFrame {
-                frame_id: 2, method_name: "b".into(), method_signature: "".into(),
-                source_file: "".into(), class_name: "".into(), line_num: -1, // Unknown
+                frame_id: 2, method_name: "b", method_signature: "",
+                source_file: "", class_name: "", line_num: -1, // Unknown
             },
             ResolvedStackFrame {
-                frame_id: 3, method_name: "c".into(), method_signature: "".into(),
-                source_file: "".into(), class_name: "".into(), line_num: -2, // Compiled
+                frame_id: 3, method_name: "c", method_signature: "",
+                source_file: "", class_name: "", line_num: -2, // Compiled
             },
             ResolvedStackFrame {
-                frame_id: 4, method_name: "d".into(), method_signature: "".into(),
-                source_file: "".into(), class_name: "".into(), line_num: -3, // Native
+                frame_id: 4, method_name: "d", method_signature: "",
+                source_file: "", class_name: "", line_num: -3, // Native
             },
         ];
         let index = make_test_index(frames, vec![]);
@@ -1118,8 +1119,8 @@ mod tests {
     #[test]
     fn test_build_stack_frames_batch_schema() {
         let frames = vec![ResolvedStackFrame {
-            frame_id: 1, method_name: "m".into(), method_signature: "()V".into(),
-            source_file: "X.java".into(), class_name: "X".into(), line_num: 1,
+            frame_id: 1, method_name: "m", method_signature: "()V",
+            source_file: "X.java", class_name: "X", line_num: 1,
         }];
         let index = make_test_index(frames, vec![]);
         let wb = build_stack_frames_batch(&index).unwrap();
@@ -1246,12 +1247,12 @@ mod tests {
     fn test_both_batches_from_populated_index() {
         let frames = vec![
             ResolvedStackFrame {
-                frame_id: 100, method_name: "run".into(), method_signature: "()V".into(),
-                source_file: "Thread.java".into(), class_name: "java.lang.Thread".into(), line_num: 748,
+                frame_id: 100, method_name: "run", method_signature: "()V",
+                source_file: "Thread.java", class_name: "java.lang.Thread", line_num: 748,
             },
             ResolvedStackFrame {
-                frame_id: 200, method_name: "main".into(), method_signature: "([Ljava/lang/String;)V".into(),
-                source_file: "App.java".into(), class_name: "com.example.App".into(), line_num: 15,
+                frame_id: 200, method_name: "main", method_signature: "([Ljava/lang/String;)V",
+                source_file: "App.java", class_name: "com.example.App", line_num: 15,
             },
         ];
         let traces = vec![ResolvedStackTrace {

--- a/src/hprof_index.rs
+++ b/src/hprof_index.rs
@@ -1,8 +1,25 @@
 use std::collections::HashMap;
 use dashmap::DashMap;
-use jvm_hprof::{Hprof, Id, LoadClass, Record, RecordTag, EzClass, build_type_hierarchy_field_descriptors};
+use jvm_hprof::{Hprof, Id, LineNum, LoadClass, Record, RecordTag, EzClass, build_type_hierarchy_field_descriptors};
 use jvm_hprof::heap_dump::{FieldDescriptor, PrimitiveArrayType, SubRecord};
 use rayon::prelude::*;
+
+/// Resolved stack frame with string names (not raw IDs).
+pub(crate) struct ResolvedStackFrame {
+    pub frame_id: u64,
+    pub method_name: String,
+    pub method_signature: String,
+    pub source_file: String,
+    pub class_name: String,
+    pub line_num: i32, // >0 = normal, -1 = unknown, -2 = compiled, -3 = native
+}
+
+/// Resolved stack trace with frame IDs expanded.
+pub(crate) struct ResolvedStackTrace {
+    pub stack_trace_serial: u32,
+    pub thread_serial: u32,
+    pub frame_ids: Vec<u64>,
+}
 
 pub(crate) struct HprofIndex<'a> {
     pub utf8: HashMap<Id, &'a str>,
@@ -13,6 +30,8 @@ pub(crate) struct HprofIndex<'a> {
     pub class_instance_field_descriptors: HashMap<Id, Vec<FieldDescriptor>>,
     /// For each class, the declaring class name for each field descriptor (parallel to class_instance_field_descriptors)
     pub class_field_declaring_classes: HashMap<Id, Vec<&'a str>>,
+    pub stack_frames: Vec<ResolvedStackFrame>,
+    pub stack_traces: Vec<ResolvedStackTrace>,
 }
 
 impl<'a> HprofIndex<'a> {
@@ -36,6 +55,11 @@ impl<'a> HprofIndex<'a> {
         let mut utf8 = HashMap::new();
         let mut load_classes = HashMap::new();
         let mut segments: Vec<Record<'a>> = Vec::new();
+        // Collect raw stack frames/traces — resolve names after utf8 + load_classes are complete
+        let mut raw_stack_frames = Vec::new();
+        let mut raw_stack_traces = Vec::new();
+        // serial → class_obj_id mapping for resolving StackFrame.class_serial → class name
+        let mut class_serial_to_obj_id: HashMap<u32, Id> = HashMap::new();
 
         for r in hprof.records_iter().map(|r| r.unwrap()) {
             match r.tag() {
@@ -46,7 +70,16 @@ impl<'a> HprofIndex<'a> {
                 }
                 RecordTag::LoadClass => {
                     let lc = r.as_load_class().unwrap().unwrap();
+                    class_serial_to_obj_id.insert(lc.class_serial().num(), lc.class_obj_id());
                     load_classes.insert(lc.class_obj_id(), lc);
+                }
+                RecordTag::StackFrame => {
+                    let sf = r.as_stack_frame().unwrap().unwrap();
+                    raw_stack_frames.push(sf);
+                }
+                RecordTag::StackTrace => {
+                    let st = r.as_stack_trace().unwrap().unwrap();
+                    raw_stack_traces.push(st);
                 }
                 RecordTag::HeapDump | RecordTag::HeapDumpSegment => {
                     segments.push(r);
@@ -54,9 +87,47 @@ impl<'a> HprofIndex<'a> {
                 _ => {}
             }
         }
+
+        // Resolve stack frame names from utf8 + load_classes (parallel — can be 30K+ frames)
+        let stack_frames: Vec<ResolvedStackFrame> = raw_stack_frames.par_iter().map(|sf| {
+            let method_name = utf8.get(&sf.method_name_id())
+                .unwrap_or(&"(unknown)").to_string();
+            let method_signature = utf8.get(&sf.method_signature_id())
+                .unwrap_or(&"(unknown)").to_string();
+            let source_file = utf8.get(&sf.source_file_name_id())
+                .unwrap_or(&"(unknown)").to_string();
+            let class_name = class_serial_to_obj_id.get(&sf.class_serial().num())
+                .and_then(|obj_id| load_classes.get(obj_id))
+                .and_then(|lc| utf8.get(&lc.class_name_id()))
+                .unwrap_or(&"(unknown)").to_string();
+            let line_num = match sf.line_num() {
+                LineNum::Normal(n) => n as i32,
+                LineNum::Unknown => -1,
+                LineNum::CompiledMethod => -2,
+                LineNum::NativeMethod => -3,
+            };
+            ResolvedStackFrame {
+                frame_id: sf.id().id(),
+                method_name,
+                method_signature,
+                source_file,
+                class_name,
+                line_num,
+            }
+        }).collect();
+
+        let stack_traces: Vec<ResolvedStackTrace> = raw_stack_traces.par_iter().map(|st| {
+            ResolvedStackTrace {
+                stack_trace_serial: st.stack_trace_serial().num(),
+                thread_serial: st.thread_serial().num(),
+                frame_ids: st.frame_ids().map(|id| id.unwrap().id()).collect(),
+            }
+        }).collect();
+
         let phase1a_dur = t0.elapsed();
-        println!("  Phase 1a (sequential scan): {:.1}s — {} utf8, {} load_classes, {} segments",
-            phase1a_dur.as_secs_f64(), utf8.len(), load_classes.len(), segments.len());
+        println!("  Phase 1a (sequential scan): {:.1}s — {} utf8, {} load_classes, {} segments, {} stack_frames, {} stack_traces",
+            phase1a_dur.as_secs_f64(), utf8.len(), load_classes.len(), segments.len(),
+            stack_frames.len(), stack_traces.len());
 
         // Phase 1b: Parallel sub-record processing.
         // Shared concurrent maps — rayon threads insert directly, no merge needed.
@@ -137,7 +208,74 @@ impl<'a> HprofIndex<'a> {
             prim_array_obj_id_to_type,
             class_instance_field_descriptors,
             class_field_declaring_classes,
+            stack_frames,
+            stack_traces,
         };
         (index, segments)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolved_stack_frame_fields() {
+        let frame = ResolvedStackFrame {
+            frame_id: 12345,
+            method_name: "processRecord".to_string(),
+            method_signature: "(Lcom/linkedin/venice/Record;)V".to_string(),
+            source_file: "Ingestion.java".to_string(),
+            class_name: "com.linkedin.venice.Ingestion".to_string(),
+            line_num: 42,
+        };
+        assert_eq!(frame.frame_id, 12345);
+        assert_eq!(frame.method_name, "processRecord");
+        assert_eq!(frame.method_signature, "(Lcom/linkedin/venice/Record;)V");
+        assert_eq!(frame.source_file, "Ingestion.java");
+        assert_eq!(frame.class_name, "com.linkedin.venice.Ingestion");
+        assert_eq!(frame.line_num, 42);
+    }
+
+    #[test]
+    fn test_resolved_stack_frame_special_line_numbers() {
+        // Verify the line number encoding contract
+        let unknown = ResolvedStackFrame {
+            frame_id: 1, method_name: "".into(), method_signature: "".into(),
+            source_file: "".into(), class_name: "".into(), line_num: -1,
+        };
+        let compiled = ResolvedStackFrame {
+            frame_id: 2, method_name: "".into(), method_signature: "".into(),
+            source_file: "".into(), class_name: "".into(), line_num: -2,
+        };
+        let native = ResolvedStackFrame {
+            frame_id: 3, method_name: "".into(), method_signature: "".into(),
+            source_file: "".into(), class_name: "".into(), line_num: -3,
+        };
+        assert_eq!(unknown.line_num, -1);
+        assert_eq!(compiled.line_num, -2);
+        assert_eq!(native.line_num, -3);
+    }
+
+    #[test]
+    fn test_resolved_stack_trace_fields() {
+        let trace = ResolvedStackTrace {
+            stack_trace_serial: 100,
+            thread_serial: 5,
+            frame_ids: vec![1000, 2000, 3000],
+        };
+        assert_eq!(trace.stack_trace_serial, 100);
+        assert_eq!(trace.thread_serial, 5);
+        assert_eq!(trace.frame_ids, vec![1000, 2000, 3000]);
+    }
+
+    #[test]
+    fn test_resolved_stack_trace_empty_frames() {
+        let trace = ResolvedStackTrace {
+            stack_trace_serial: 1,
+            thread_serial: 1,
+            frame_ids: vec![],
+        };
+        assert!(trace.frame_ids.is_empty());
     }
 }

--- a/src/hprof_index.rs
+++ b/src/hprof_index.rs
@@ -5,12 +5,13 @@ use jvm_hprof::heap_dump::{FieldDescriptor, PrimitiveArrayType, SubRecord};
 use rayon::prelude::*;
 
 /// Resolved stack frame with string names (not raw IDs).
-pub(crate) struct ResolvedStackFrame {
+/// Borrows from the HPROF's UTF8 string table to avoid allocations.
+pub(crate) struct ResolvedStackFrame<'a> {
     pub frame_id: u64,
-    pub method_name: String,
-    pub method_signature: String,
-    pub source_file: String,
-    pub class_name: String,
+    pub method_name: &'a str,
+    pub method_signature: &'a str,
+    pub source_file: &'a str,
+    pub class_name: &'a str,
     pub line_num: i32, // >0 = normal, -1 = unknown, -2 = compiled, -3 = native
 }
 
@@ -30,7 +31,7 @@ pub(crate) struct HprofIndex<'a> {
     pub class_instance_field_descriptors: HashMap<Id, Vec<FieldDescriptor>>,
     /// For each class, the declaring class name for each field descriptor (parallel to class_instance_field_descriptors)
     pub class_field_declaring_classes: HashMap<Id, Vec<&'a str>>,
-    pub stack_frames: Vec<ResolvedStackFrame>,
+    pub stack_frames: Vec<ResolvedStackFrame<'a>>,
     pub stack_traces: Vec<ResolvedStackTrace>,
 }
 
@@ -90,16 +91,13 @@ impl<'a> HprofIndex<'a> {
 
         // Resolve stack frame names from utf8 + load_classes (parallel — can be 30K+ frames)
         let stack_frames: Vec<ResolvedStackFrame> = raw_stack_frames.par_iter().map(|sf| {
-            let method_name = utf8.get(&sf.method_name_id())
-                .unwrap_or(&"(unknown)").to_string();
-            let method_signature = utf8.get(&sf.method_signature_id())
-                .unwrap_or(&"(unknown)").to_string();
-            let source_file = utf8.get(&sf.source_file_name_id())
-                .unwrap_or(&"(unknown)").to_string();
-            let class_name = class_serial_to_obj_id.get(&sf.class_serial().num())
+            let method_name = *utf8.get(&sf.method_name_id()).unwrap_or(&"(unknown)");
+            let method_signature = *utf8.get(&sf.method_signature_id()).unwrap_or(&"(unknown)");
+            let source_file = *utf8.get(&sf.source_file_name_id()).unwrap_or(&"(unknown)");
+            let class_name = *class_serial_to_obj_id.get(&sf.class_serial().num())
                 .and_then(|obj_id| load_classes.get(obj_id))
                 .and_then(|lc| utf8.get(&lc.class_name_id()))
-                .unwrap_or(&"(unknown)").to_string();
+                .unwrap_or(&"(unknown)");
             let line_num = match sf.line_num() {
                 LineNum::Normal(n) => n as i32,
                 LineNum::Unknown => -1,
@@ -116,7 +114,8 @@ impl<'a> HprofIndex<'a> {
             }
         }).collect();
 
-        let stack_traces: Vec<ResolvedStackTrace> = raw_stack_traces.par_iter().map(|st| {
+        // Stack traces are typically few (hundreds) with trivial per-item work — sequential is faster
+        let stack_traces: Vec<ResolvedStackTrace> = raw_stack_traces.iter().map(|st| {
             ResolvedStackTrace {
                 stack_trace_serial: st.stack_trace_serial().num(),
                 thread_serial: st.thread_serial().num(),
@@ -223,10 +222,10 @@ mod tests {
     fn test_resolved_stack_frame_fields() {
         let frame = ResolvedStackFrame {
             frame_id: 12345,
-            method_name: "processRecord".to_string(),
-            method_signature: "(Lcom/linkedin/venice/Record;)V".to_string(),
-            source_file: "Ingestion.java".to_string(),
-            class_name: "com.linkedin.venice.Ingestion".to_string(),
+            method_name: "processRecord",
+            method_signature: "(Lcom/linkedin/venice/Record;)V",
+            source_file: "Ingestion.java",
+            class_name: "com.linkedin.venice.Ingestion",
             line_num: 42,
         };
         assert_eq!(frame.frame_id, 12345);
@@ -241,16 +240,16 @@ mod tests {
     fn test_resolved_stack_frame_special_line_numbers() {
         // Verify the line number encoding contract
         let unknown = ResolvedStackFrame {
-            frame_id: 1, method_name: "".into(), method_signature: "".into(),
-            source_file: "".into(), class_name: "".into(), line_num: -1,
+            frame_id: 1, method_name: "", method_signature: "",
+            source_file: "", class_name: "", line_num: -1,
         };
         let compiled = ResolvedStackFrame {
-            frame_id: 2, method_name: "".into(), method_signature: "".into(),
-            source_file: "".into(), class_name: "".into(), line_num: -2,
+            frame_id: 2, method_name: "", method_signature: "",
+            source_file: "", class_name: "", line_num: -2,
         };
         let native = ResolvedStackFrame {
-            frame_id: 3, method_name: "".into(), method_signature: "".into(),
-            source_file: "".into(), class_name: "".into(), line_num: -3,
+            frame_id: 3, method_name: "", method_signature: "",
+            source_file: "", class_name: "", line_num: -3,
         };
         assert_eq!(unknown.line_num, -1);
         assert_eq!(compiled.line_num, -2);


### PR DESCRIPTION
## Summary

Parse HPROF `StackFrame` and `StackTrace` records and output them as Parquet files, enabling downstream thread stack analysis from heap dumps.

### What changed

**`src/hprof_index.rs`** — New structs and collection logic:
- `ResolvedStackFrame<'a>` — borrows `&'a str` from the HPROF UTF8 string table (zero-copy, no heap allocations for names)
- `ResolvedStackTrace` — `stack_trace_serial`, `thread_serial`, `frame_ids: Vec<u64>`
- Phase 1a sequential scan now collects `StackFrame` and `StackTrace` HPROF records alongside UTF8/LoadClass
- Builds `class_serial_to_obj_id` map to resolve StackFrame class serials → class names
- Frame name resolution uses `rayon::par_iter` (30K+ frames benefit from parallelism)
- Trace resolution uses sequential `iter()` (hundreds of traces with trivial per-item work)

**`src/commands/dump_to_parquet.rs`** — New batch builders:
- `build_stack_frames_batch()` → `_stack_frames.parquet`
  - Columns: `frame_id` (UInt64), `class_name`, `method_name`, `method_signature`, `source_file` (Utf8), `line_num` (Int32)
  - Line number encoding: positive = normal, -1 = unknown, -2 = compiled method, -3 = native method
- `build_stack_traces_batch()` → `_stack_traces.parquet`
  - Columns: `stack_trace_serial` (UInt32), `thread_serial` (UInt32), `frame_ids` (List\<UInt64\>)
  - `UInt64Builder` pre-sized with `total_frame_refs` capacity to avoid reallocation
- Both route through the existing `ShardedWriterPool` (consistent with static fields, GC roots)

### Performance considerations
- `ResolvedStackFrame` borrows `&'a str` from the UTF8 table — eliminates 120K+ heap allocations for typical 30K-frame dumps
- Frame resolution parallelized via `rayon::par_iter` (each frame does 3-4 HashMap lookups + string borrows)
- Trace resolution kept sequential — per-item work is two `u32` copies + frame ID collection; rayon overhead would exceed benefit
- `ListBuilder` inner buffer pre-sized to exact total frame references count

### New parquet output files

```
parquet/
├── _stack_frames.parquet    # One row per unique stack frame
└── _stack_traces.parquet    # One row per stack trace (links thread → frames)
```

These files enable:
- **Thread pool identification** — group `java.lang.Thread` instances by their `stack_trace_serial` → frame patterns
- **Blocked/waiting thread detection** — correlate thread state with stack patterns
- **Local variable resolution** — join `JavaStackFrame` GC root entries (`obj_id`, `thread_serial`, `frame_index`) with frames/traces to see what objects are on each thread's stack
- **OOM thread attribution** — find which thread threw `OutOfMemoryError` via GC root linkage

### Example DuckDB queries on the new files

```sql
-- Top 10 methods by frequency across all stack traces
SELECT sf.class_name, sf.method_name, COUNT(*) as appearances
FROM '_stack_traces.parquet' st, UNNEST(st.frame_ids) AS t(fid)
JOIN '_stack_frames.parquet' sf ON sf.frame_id = t.fid
GROUP BY sf.class_name, sf.method_name
ORDER BY appearances DESC LIMIT 10;

-- Thread count by stack depth
SELECT len(frame_ids) as depth, COUNT(*) as thread_count
FROM '_stack_traces.parquet'
GROUP BY depth ORDER BY thread_count DESC;

-- Find threads with a specific method on their stack
SELECT st.stack_trace_serial, st.thread_serial, sf.class_name, sf.method_name
FROM '_stack_traces.parquet' st, UNNEST(st.frame_ids) AS t(fid)
JOIN '_stack_frames.parquet' sf ON sf.frame_id = t.fid
WHERE sf.method_name = 'sendControlMessageWithRetries';
```

## Test plan

- [x] 14 unit tests with 100% coverage of new code paths
- [x] `build_stack_frames_batch`: empty → None, single frame, multiple frames, all 4 line_num variants, schema validation
- [x] `build_stack_traces_batch`: empty → None, single trace, multiple traces with varying depths (including empty frame list), schema validation
- [x] Integration test: cross-references trace `frame_ids` against frame `frame_id` values
- [x] `ResolvedStackFrame`/`ResolvedStackTrace` struct field access tests
- [x] Validated against production 6.7GB Venice server heap dump (30K+ frames, 22K+ traces)
- [x] No new compiler warnings
- [x] Code reviewed for reuse, quality, and efficiency (3 parallel review passes)