### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone jvm-hprof dependency
+        run: |
+          # Cargo.toml references jvm-hprof at ../../bitbucket/jvm-hprof-rs-li-hackweek
+          # Recreate the expected directory layout relative to this repo
+          mkdir -p ../../bitbucket
+          git clone https://bitbucket.org/ZacAttack/jvm-hprof-rs-li-hackweek.git ../../bitbucket/jvm-hprof-rs-li-hackweek
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone jvm-hprof dependency
+        run: |
+          mkdir -p ../../bitbucket
+          git clone https://bitbucket.org/ZacAttack/jvm-hprof-rs-li-hackweek.git ../../bitbucket/jvm-hprof-rs-li-hackweek
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-clippy-
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt -- --check


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI pipeline that runs on every push to `main` and on all pull requests.

### Jobs

| Job | What it does | Duration |
|-----|-------------|----------|
| **test** | `cargo build` + `cargo test` | ~2-3 min |
| **clippy** | `cargo clippy -- -D warnings` (lint) | ~2-3 min |
| **fmt** | `cargo fmt -- --check` (format) | ~30s |

All three jobs run in parallel.

### Dependency handling

The `jvm-hprof` crate is referenced via relative path (`../../bitbucket/jvm-hprof-rs-li-hackweek`). The CI workflow clones it from Bitbucket to match the expected directory layout. This works because the Bitbucket repo is public.

### Caching

Cargo registry, git index, and build artifacts are cached between runs using `actions/cache@v4`, keyed on `Cargo.lock` + `Cargo.toml` hashes.

## Test plan

- [x] Workflow syntax validated
- [x] jvm-hprof clone step recreates the relative path layout
- [x] Cache keys include dependency hashes for invalidation
- [x] Format check runs without needing the jvm-hprof dependency (no build required)